### PR TITLE
bugfix: verify lookup call support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/mrezagolestan/kavenegar-go
+module github.com/kavenegar/kavenegar-go
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/kavenegar/kavenegar-go
+module github.com/mrezagolestan/kavenegar-go
 
 go 1.14

--- a/verify.go
+++ b/verify.go
@@ -33,8 +33,8 @@ const (
 )
 
 var VerifyLookupTypeMap = map[VerifyLookupType]string{
-	Type_VerifyLookup_Sms:  "0",
-	Type_VerifyLookup_Call: "1",
+	Type_VerifyLookup_Sms:  "sms",
+	Type_VerifyLookup_Call: "call",
 }
 
 func (t VerifyLookupType) String() string {

--- a/verify.go
+++ b/verify.go
@@ -25,18 +25,9 @@ func NewVerifyService(client *Client) *VerifyService {
 	return m
 }
 
-type VerifyLookupType int
+type VerifyLookupType string
 
 const (
-	Type_VerifyLookup_Sms VerifyLookupType = iota
-	Type_VerifyLookup_Call
+	Type_VerifyLookup_Sms  VerifyLookupType = "sms"
+	Type_VerifyLookup_Call VerifyLookupType = "call"
 )
-
-var VerifyLookupTypeMap = map[VerifyLookupType]string{
-	Type_VerifyLookup_Sms:  "sms",
-	Type_VerifyLookup_Call: "call",
-}
-
-func (t VerifyLookupType) String() string {
-	return VerifyLookupTypeMap[t]
-}


### PR DESCRIPTION
i decide to call a verify lookup template to call receptor, it was buggy as i saw.
in verify.go setting was done to call verify lookup api by type:0 for sms and type:1 for call , while current document is based on type: sms & type: call.
so i change VerifyLookupType to support it, and remove VerifyLookupTypeMap because had not been used.
 